### PR TITLE
Fix anchor scrolling with GSAP pin

### DIFF
--- a/js/animation.js
+++ b/js/animation.js
@@ -332,6 +332,10 @@ document.fonts.ready.then(() => {
     });
   });
 
+  // все анимации и ScrollTrigger'ы инициализированы
+  ScrollTrigger.refresh();
+  window.dispatchEvent(new Event('animationsReady'));
+
 });
 
 

--- a/js/handle.js
+++ b/js/handle.js
@@ -349,4 +349,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   window.addEventListener("load", scrollToHash);
+
+  // когда анимации и ScrollTrigger инициализированы (см. animation.js)
+  window.addEventListener('animationsReady', scrollToHash);
 });


### PR DESCRIPTION
## Summary
- ensure ScrollTrigger refreshes and anchor scrolls after animations are ready
- trigger hash scrolling when animations finish initializing

## Testing
- `node --check js/animation.js`
- `node --check js/handle.js`


------
https://chatgpt.com/codex/tasks/task_e_688b1bb22938832384f5d9896f5fe88a